### PR TITLE
Feature/us 022 imp add validations to post operation to create users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,15 @@
 					</processTypes>
 				</configuration>
 			</plugin>
-		</plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
 	</build>
 
 	<profiles>

--- a/src/main/java/com/agilethought/atsceapi/exception/BadRequestException.java
+++ b/src/main/java/com/agilethought/atsceapi/exception/BadRequestException.java
@@ -1,0 +1,11 @@
+package com.agilethought.atsceapi.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException{
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
+++ b/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
@@ -2,9 +2,9 @@ package com.agilethought.atsceapi.exception;
 
 public class ErrorMessage {
 
-    public static final String badRequestMessage = "The field ";
-    public static final String badRequestMessageType = "needs to be 1 or 2";
-    public static final String badRequestMessageFirstNameLastName = "is wrong because you need to type it";
-    public static final String badRequestMessageEmailPassword = "is wrong because it doesn't have the correct format";
-    public static final String badRequestMessageEmailInDB = "can not be store, because it already exist in the Database";
+    public static final String BAD_REQUEST_MESSAGE = "The field ";
+    public static final String BAD_REQUEST_MESSAGE_TYPE = "needs to be 1 or 2";
+    public static final String BAD_REQUEST_MESSAGE_FIRST_NAME_LASTNAME = "is wrong because you need to type it";
+    public static final String BAD_REQUEST_MESSAGE_EMAIL_PASSWORD = "is wrong because it doesn't have the correct format";
+    public static final String BAD_REQUEST_MESSAGE_EMAIL_IN_DB = "can not be store, because it already exist in the Database";
 }

--- a/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
+++ b/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
@@ -1,0 +1,5 @@
+package com.agilethought.atsceapi.exception;
+
+public class ErrorMessage {
+    public static final String badRequestMessage = "You cannot obtain the ";
+}

--- a/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
+++ b/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
@@ -1,5 +1,10 @@
 package com.agilethought.atsceapi.exception;
 
 public class ErrorMessage {
-    public static final String badRequestMessage = "You cannot obtain the ";
+
+    public static final String badRequestMessage = "The field ";
+    public static final String badRequestMessageType = "needs to be 1 or 2";
+    public static final String badRequestMessageFirstNameLastName = "is wrong because you need to type it";
+    public static final String badRequestMessageEmailPassword = "is wrong because it doesn't have the correct format";
+    public static final String badRequestMessageEmailInDB = "can not be store, because it already exist in the Database";
 }

--- a/src/main/java/com/agilethought/atsceapi/repository/UserRepository.java
+++ b/src/main/java/com/agilethought/atsceapi/repository/UserRepository.java
@@ -14,4 +14,6 @@ public interface UserRepository extends MongoRepository<User, String> {
 
 	@Query("{ 'email' : ?0, 'password' : ?1 }")
 	List<User> findUsersByEmail(String email, String password);
+
+	boolean existsByEmail(String email);
 }

--- a/src/main/java/com/agilethought/atsceapi/service/UserServiceImpl.java
+++ b/src/main/java/com/agilethought/atsceapi/service/UserServiceImpl.java
@@ -78,6 +78,8 @@ public class UserServiceImpl implements UserService {
 	public NewUserResponse createUser(NewUserRequest request) {
 		User user = orikaMapperFacade.map(request, User.class);
 		userValidator.validate(user);
+		user.setFirstName(user.getFirstName().toUpperCase());
+		user.setLastName(user.getLastName().toUpperCase());
 		User savedUsers = userRepository.save(user);
 		return orikaMapperFacade.map(savedUsers, NewUserResponse.class);
 	}

--- a/src/main/java/com/agilethought/atsceapi/service/UserServiceImpl.java
+++ b/src/main/java/com/agilethought/atsceapi/service/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.agilethought.atsceapi.service;
 import java.util.List;
 import java.util.Optional;
 
+import com.agilethought.atsceapi.validator.UserValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -14,7 +15,6 @@ import com.agilethought.atsceapi.exception.NotFoundException;
 import com.agilethought.atsceapi.exception.UnauthorizedException;
 import com.agilethought.atsceapi.model.User;
 import com.agilethought.atsceapi.repository.UserRepository;
-import com.agilethought.atsceapi.validator.LoginValidator;
 import com.agilethought.atsceapi.validator.Validator;
 
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +32,9 @@ public class UserServiceImpl implements UserService {
 	
 	@Autowired
 	private Validator<LoginData> loginValidator;
+
+	@Autowired
+	private UserValidator userValidator;
 	
 	@Override
 	public UserDTO loginMethod(LoginData loginData) {
@@ -74,8 +77,8 @@ public class UserServiceImpl implements UserService {
 	@Override
 	public NewUserResponse createUser(NewUserRequest request) {
 		User user = orikaMapperFacade.map(request, User.class);
+		userValidator.validate(user);
 		User savedUsers = userRepository.save(user);
-
 		return orikaMapperFacade.map(savedUsers, NewUserResponse.class);
 	}
 }

--- a/src/main/java/com/agilethought/atsceapi/validator/UserValidator.java
+++ b/src/main/java/com/agilethought/atsceapi/validator/UserValidator.java
@@ -1,7 +1,7 @@
 package com.agilethought.atsceapi.validator;
 
 import com.agilethought.atsceapi.exception.BadRequestException;
-import static com.agilethought.atsceapi.exception.ErrorMessage.badRequestMessage;
+import static com.agilethought.atsceapi.exception.ErrorMessage.*;
 import com.agilethought.atsceapi.model.User;
 import com.agilethought.atsceapi.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +13,7 @@ import static com.agilethought.atsceapi.validator.ValidationUtils.*;
 @Service
 @Slf4j
 public class UserValidator implements Validator<User> {
+
     @Autowired
     private UserRepository userRepository;
 
@@ -24,44 +25,41 @@ public class UserValidator implements Validator<User> {
         validateEmailFormat(user.getEmail());
         validatePasswordFormat(user.getPassword());
         validateEmailInTheDataBase(user.getEmail());
-        user.setFirstName(user.getFirstName().toUpperCase());
-        user.setLastName(user.getLastName().toUpperCase());
     }
 
     private void validateUserTypeField(int type) {
         if(type < 1 || type > 2) {
-            log.info("fail type");
-            throw new BadRequestException(badRequestMessage + "*type* because type needs to be 1 or 2");
+            throw new BadRequestException(badRequestMessage + "*TYPE*" + " " + badRequestMessageType);
         }
     }
 
     private void validateUserFirstName(String firstName) {
         if(!isStringValid(firstName) || !isStringLowerCase(firstName)) {
-            throw new BadRequestException(badRequestMessage + "*name* because you need to type it");
+            throw new BadRequestException(badRequestMessage + "*NAME*" + " " + badRequestMessageFirstNameLastName);
         }
     }
 
     private void validateUserLastName(String lastName) {
         if(!isStringValid(lastName) || !isStringLowerCase(lastName)) {
-            throw new BadRequestException(badRequestMessage + "*lastname* because you need to type it");
+            throw new BadRequestException(badRequestMessage + "*LASTNAME*" + " " + badRequestMessageFirstNameLastName);
         }
     }
 
     private void validateEmailFormat(String email) {
         if(!isStringValid(email) || !isStringLowerCase(email) || !isValidEmail(email)) {
-            throw new BadRequestException(badRequestMessage + "*email* because it doesn't have the correct format");
+            throw new BadRequestException(badRequestMessage + "*EMAIL*" + " " + badRequestMessageEmailPassword);
         }
     }
 
     private void validatePasswordFormat(String password) {
-        if(!isStringValid(password) || !isStringLowerCase(password) || !isValidatePassword(password)) {
-            throw new BadRequestException(badRequestMessage + "*password* because it doesn't have the correct format");
+        if(!isStringValid(password) || !isStringLowerCase(password) || !isValidPassword(password)) {
+            throw new BadRequestException(badRequestMessage + "*PASSWORD*" + " " + badRequestMessageEmailPassword);
         }
     }
 
     private void validateEmailInTheDataBase(String email) {
         if(userRepository.existsByEmail(email)) {
-            throw new BadRequestException(badRequestMessage + "*email* because it already exist in the Database");
+            throw new BadRequestException(badRequestMessage + "*EMAIL*" + " " + badRequestMessageEmailInDB);
         }
     }
 }

--- a/src/main/java/com/agilethought/atsceapi/validator/UserValidator.java
+++ b/src/main/java/com/agilethought/atsceapi/validator/UserValidator.java
@@ -4,14 +4,12 @@ import com.agilethought.atsceapi.exception.BadRequestException;
 import static com.agilethought.atsceapi.exception.ErrorMessage.*;
 import com.agilethought.atsceapi.model.User;
 import com.agilethought.atsceapi.repository.UserRepository;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import static com.agilethought.atsceapi.validator.ValidationUtils.*;
 
 @Service
-@Slf4j
 public class UserValidator implements Validator<User> {
 
     @Autowired
@@ -29,37 +27,37 @@ public class UserValidator implements Validator<User> {
 
     private void validateUserTypeField(int type) {
         if(type < 1 || type > 2) {
-            throw new BadRequestException(badRequestMessage + "*TYPE*" + " " + badRequestMessageType);
+            throw new BadRequestException(BAD_REQUEST_MESSAGE + "*TYPE*" + " " + BAD_REQUEST_MESSAGE_TYPE);
         }
     }
 
     private void validateUserFirstName(String firstName) {
         if(!isStringValid(firstName) || !isStringLowerCase(firstName)) {
-            throw new BadRequestException(badRequestMessage + "*NAME*" + " " + badRequestMessageFirstNameLastName);
+            throw new BadRequestException(BAD_REQUEST_MESSAGE + "*NAME*" + " " + BAD_REQUEST_MESSAGE_FIRST_NAME_LASTNAME);
         }
     }
 
     private void validateUserLastName(String lastName) {
         if(!isStringValid(lastName) || !isStringLowerCase(lastName)) {
-            throw new BadRequestException(badRequestMessage + "*LASTNAME*" + " " + badRequestMessageFirstNameLastName);
+            throw new BadRequestException(BAD_REQUEST_MESSAGE + "*LASTNAME*" + " " + BAD_REQUEST_MESSAGE_FIRST_NAME_LASTNAME);
         }
     }
 
     private void validateEmailFormat(String email) {
         if(!isStringValid(email) || !isStringLowerCase(email) || !isValidEmail(email)) {
-            throw new BadRequestException(badRequestMessage + "*EMAIL*" + " " + badRequestMessageEmailPassword);
+            throw new BadRequestException(BAD_REQUEST_MESSAGE + "*EMAIL*" + " " + BAD_REQUEST_MESSAGE_EMAIL_PASSWORD);
         }
     }
 
     private void validatePasswordFormat(String password) {
         if(!isStringValid(password) || !isStringLowerCase(password) || !isValidPassword(password)) {
-            throw new BadRequestException(badRequestMessage + "*PASSWORD*" + " " + badRequestMessageEmailPassword);
+            throw new BadRequestException(BAD_REQUEST_MESSAGE + "*PASSWORD*" + " " + BAD_REQUEST_MESSAGE_EMAIL_PASSWORD);
         }
     }
 
     private void validateEmailInTheDataBase(String email) {
         if(userRepository.existsByEmail(email)) {
-            throw new BadRequestException(badRequestMessage + "*EMAIL*" + " " + badRequestMessageEmailInDB);
+            throw new BadRequestException(BAD_REQUEST_MESSAGE + "*EMAIL*" + " " + BAD_REQUEST_MESSAGE_EMAIL_IN_DB);
         }
     }
 }

--- a/src/main/java/com/agilethought/atsceapi/validator/UserValidator.java
+++ b/src/main/java/com/agilethought/atsceapi/validator/UserValidator.java
@@ -1,0 +1,67 @@
+package com.agilethought.atsceapi.validator;
+
+import com.agilethought.atsceapi.exception.BadRequestException;
+import static com.agilethought.atsceapi.exception.ErrorMessage.badRequestMessage;
+import com.agilethought.atsceapi.model.User;
+import com.agilethought.atsceapi.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import static com.agilethought.atsceapi.validator.ValidationUtils.*;
+
+@Service
+@Slf4j
+public class UserValidator implements Validator<User> {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public void validate(User user) {
+        validateUserTypeField(user.getType());
+        validateUserFirstName(user.getFirstName());
+        validateUserLastName(user.getLastName());
+        validateEmailFormat(user.getEmail());
+        validatePasswordFormat(user.getPassword());
+        validateEmailInTheDataBase(user.getEmail());
+        user.setFirstName(user.getFirstName().toUpperCase());
+        user.setLastName(user.getLastName().toUpperCase());
+    }
+
+    private void validateUserTypeField(int type) {
+        if(type < 1 || type > 2) {
+            log.info("fail type");
+            throw new BadRequestException(badRequestMessage + "*type* because type needs to be 1 or 2");
+        }
+    }
+
+    private void validateUserFirstName(String firstName) {
+        if(!isStringValid(firstName) || !isStringLowerCase(firstName)) {
+            throw new BadRequestException(badRequestMessage + "*name* because you need to type it");
+        }
+    }
+
+    private void validateUserLastName(String lastName) {
+        if(!isStringValid(lastName) || !isStringLowerCase(lastName)) {
+            throw new BadRequestException(badRequestMessage + "*lastname* because you need to type it");
+        }
+    }
+
+    private void validateEmailFormat(String email) {
+        if(!isStringValid(email) || !isStringLowerCase(email) || !isValidEmail(email)) {
+            throw new BadRequestException(badRequestMessage + "*email* because it doesn't have the correct format");
+        }
+    }
+
+    private void validatePasswordFormat(String password) {
+        if(!isStringValid(password) || !isStringLowerCase(password) || !isValidatePassword(password)) {
+            throw new BadRequestException(badRequestMessage + "*password* because it doesn't have the correct format");
+        }
+    }
+
+    private void validateEmailInTheDataBase(String email) {
+        if(userRepository.existsByEmail(email)) {
+            throw new BadRequestException(badRequestMessage + "*email* because it already exist in the Database");
+        }
+    }
+}

--- a/src/main/java/com/agilethought/atsceapi/validator/ValidationUtils.java
+++ b/src/main/java/com/agilethought/atsceapi/validator/ValidationUtils.java
@@ -4,6 +4,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ValidationUtils {
+
 	public static boolean isStringValid(String str) {
 		if(str == null || str.isBlank()) {
 			return false;
@@ -24,7 +25,7 @@ public class ValidationUtils {
 		return matcherEmail.find();
 	}
 
-	static boolean isValidatePassword(String password) {
+	static boolean isValidPassword(String password) {
 		Pattern patternPassword = Pattern.compile(
 				"^(?=.*[0-9])(?=.*[a-z])(?=\\S+$).{10,}$"
 		);

--- a/src/main/java/com/agilethought/atsceapi/validator/ValidationUtils.java
+++ b/src/main/java/com/agilethought/atsceapi/validator/ValidationUtils.java
@@ -1,22 +1,34 @@
 package com.agilethought.atsceapi.validator;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class ValidationUtils {
-	public static boolean isStringLowerCase(String str) {
-		// convert String to char array
-		char[] charArray = str.toCharArray();
-		for (int i = 0; i < charArray.length; i++) {
-			// if the character is a letter
-			if (Character.isLetter(charArray[i])) {
-				// if any character is not in lower case, return false
-				if (!Character.isLowerCase(charArray[i]))
-					return false;
-			}
+	public static boolean isStringValid(String str) {
+		if(str == null || str.isBlank()) {
+			return false;
 		}
 		return true;
 	}
 
-	public static boolean isValidEmail(String email) {
-		String regex = "^[\\w-_\\.+]*[\\w-_\\.]\\@([\\w]+\\.)+[\\w]+[\\w]$";
-		return email.matches(regex);
+	static boolean isStringLowerCase(String str) {
+		return str.equals(str.toLowerCase());
+
+	}
+
+	static boolean isValidEmail(String email) {
+		Pattern patternEmail = Pattern.compile(
+				"^[_a-z0-9-]+(\\.[_a-z0-9-]+)*@" + "[a-z0-9-]+(\\.[a-z0-9-]+)*(\\.[a-z]{2,4})$"
+		);
+		Matcher matcherEmail = patternEmail.matcher(email);
+		return matcherEmail.find();
+	}
+
+	static boolean isValidatePassword(String password) {
+		Pattern patternPassword = Pattern.compile(
+				"^(?=.*[0-9])(?=.*[a-z])(?=\\S+$).{10,}$"
+		);
+		Matcher matcherPassword = patternPassword.matcher(password);
+		return matcherPassword.find();
 	}
 }

--- a/src/main/java/com/agilethought/atsceapi/validator/Validator.java
+++ b/src/main/java/com/agilethought/atsceapi/validator/Validator.java
@@ -1,7 +1,5 @@
 package com.agilethought.atsceapi.validator;
 
-import com.agilethought.atsceapi.model.User;
-
 public interface Validator<E> {
-	public void validate(E object);
+	void validate(E object);
 }


### PR DESCRIPTION
# Validations to post operation to create users
In this Pull Request, I did the validation on the data that the user gave us to create a new user. The validations before storing the user's data in the database:
- The **type** field should be only 1  (admin) or 2 (normal user)
- The fields **first name**, **last name**, **email**, **password** should be required
- The field **email** needs to be a validated email (@ + domain + extension)
- The field **password**  needs to have the correct format.:
    - At least 10 characters
    - At least 1 numeric value
-  The **email** that the user gave us needs to be unique in all the database
- The fields **first name** and **last name** will store in capital letters 