### PR TITLE
Fix bugs: create user status value and emails with the "ñ" letter

### DIFF
--- a/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
+++ b/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
@@ -4,11 +4,11 @@ public class ErrorMessage {
 
     public static final String BAD_REQUEST_MESSAGE = "The field ";
     public static final String BAD_REQUEST_MESSAGE_TYPE = "needs to be 1 or 2";
-    public static final String BAD_REQUEST_MESSAGE_FIRST_NAME_LASTNAME = "is required and you don't type it";
+    public static final String BAD_REQUEST_MESSAGE_FIRST_NAME_LASTNAME = "is required and you didn't type it";
     public static final String BAD_REQUEST_MESSAGE_EMAIL = "is not valid, because it doesn't have the correct format, " +
             "try without capital letters and the format like this xxx@domail.xxx";
     public static final String BAD_REQUEST_MESSAGE_PASSWORD = "is not valid, because it doesn't have the correct format, " +
             "try with at least 10 characters, a numeric value and without capital letters characters";
-    public static final String BAD_REQUEST_MESSAGE_EMAIL_IN_DB = "can not be store, because it already exist in the Database";
+    public static final String BAD_REQUEST_MESSAGE_EMAIL_IN_DB = "can not be store, because it already exists in the Database, try with another email";
     public static final String BAD_REQUEST_MESSAGE_STATUS = "The status needs to be 0 or 1";
 }

--- a/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
+++ b/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
@@ -5,6 +5,10 @@ public class ErrorMessage {
     public static final String BAD_REQUEST_MESSAGE = "The field ";
     public static final String BAD_REQUEST_MESSAGE_TYPE = "needs to be 1 or 2";
     public static final String BAD_REQUEST_MESSAGE_FIRST_NAME_LASTNAME = "is wrong because you need to type it";
-    public static final String BAD_REQUEST_MESSAGE_EMAIL_PASSWORD = "is wrong because it doesn't have the correct format";
+    public static final String BAD_REQUEST_MESSAGE_EMAIL = "is wrong because it doesn't have the correct format, " +
+            "try without capital letters and the format like this xxx@domail.xxx";
+    public static final String BAD_REQUEST_MESSAGE_PASSWORD = "is wrong because it doesn't have the correct format, " +
+            "try with at least 10 characters, a numeric value and without capital letters";
     public static final String BAD_REQUEST_MESSAGE_EMAIL_IN_DB = "can not be store, because it already exist in the Database";
+    public static final String BAD_REQUEST_MESSAGE_STATUS = "The status needs to be 0 or 1";
 }

--- a/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
+++ b/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
@@ -4,11 +4,11 @@ public class ErrorMessage {
 
     public static final String BAD_REQUEST_MESSAGE = "The field ";
     public static final String BAD_REQUEST_MESSAGE_TYPE = "needs to be 1 or 2";
-    public static final String BAD_REQUEST_MESSAGE_FIRST_NAME_LASTNAME = "is wrong because you need to type it";
-    public static final String BAD_REQUEST_MESSAGE_EMAIL = "is wrong because it doesn't have the correct format, " +
+    public static final String BAD_REQUEST_MESSAGE_FIRST_NAME_LASTNAME = "is required and you don't type it";
+    public static final String BAD_REQUEST_MESSAGE_EMAIL = "is not valid, because it doesn't have the correct format, " +
             "try without capital letters and the format like this xxx@domail.xxx";
-    public static final String BAD_REQUEST_MESSAGE_PASSWORD = "is wrong because it doesn't have the correct format, " +
-            "try with at least 10 characters, a numeric value and without capital letters";
+    public static final String BAD_REQUEST_MESSAGE_PASSWORD = "is not valid, because it doesn't have the correct format, " +
+            "try with at least 10 characters, a numeric value and without capital letters characters";
     public static final String BAD_REQUEST_MESSAGE_EMAIL_IN_DB = "can not be store, because it already exist in the Database";
     public static final String BAD_REQUEST_MESSAGE_STATUS = "The status needs to be 0 or 1";
 }

--- a/src/main/java/com/agilethought/atsceapi/validator/UserValidator.java
+++ b/src/main/java/com/agilethought/atsceapi/validator/UserValidator.java
@@ -67,7 +67,7 @@ public class UserValidator implements Validator<User> {
 
     private void validateEmailInTheDataBase(String email) {
         if(userRepository.existsByEmail(email)) {
-            throw new BadRequestException(BAD_REQUEST_MESSAGE + "*EMAIL*" + " " + BAD_REQUEST_MESSAGE_EMAIL_IN_DB);
+            throw new BadRequestException("The *EMAIL*" + " " + BAD_REQUEST_MESSAGE_EMAIL_IN_DB);
         }
     }
 

--- a/src/main/java/com/agilethought/atsceapi/validator/UserValidator.java
+++ b/src/main/java/com/agilethought/atsceapi/validator/UserValidator.java
@@ -22,6 +22,7 @@ public class UserValidator implements Validator<User> {
         validateUserLastName(user.getLastName());
         validateEmailFormat(user.getEmail());
         validatePasswordFormat(user.getPassword());
+        validateUserStatus(user.getStatus());
         validateEmailInTheDataBase(user.getEmail());
     }
 
@@ -32,27 +33,36 @@ public class UserValidator implements Validator<User> {
     }
 
     private void validateUserFirstName(String firstName) {
-        if(!isStringValid(firstName) || !isStringLowerCase(firstName)) {
+        if(!isStringValid(firstName)) {
             throw new BadRequestException(BAD_REQUEST_MESSAGE + "*NAME*" + " " + BAD_REQUEST_MESSAGE_FIRST_NAME_LASTNAME);
         }
     }
 
     private void validateUserLastName(String lastName) {
-        if(!isStringValid(lastName) || !isStringLowerCase(lastName)) {
+        if(!isStringValid(lastName)) {
             throw new BadRequestException(BAD_REQUEST_MESSAGE + "*LASTNAME*" + " " + BAD_REQUEST_MESSAGE_FIRST_NAME_LASTNAME);
         }
     }
 
     private void validateEmailFormat(String email) {
         if(!isStringValid(email) || !isStringLowerCase(email) || !isValidEmail(email)) {
-            throw new BadRequestException(BAD_REQUEST_MESSAGE + "*EMAIL*" + " " + BAD_REQUEST_MESSAGE_EMAIL_PASSWORD);
+            throw new BadRequestException(BAD_REQUEST_MESSAGE + "*EMAIL*" + " " + BAD_REQUEST_MESSAGE_EMAIL);
         }
     }
 
     private void validatePasswordFormat(String password) {
         if(!isStringValid(password) || !isStringLowerCase(password) || !isValidPassword(password)) {
-            throw new BadRequestException(BAD_REQUEST_MESSAGE + "*PASSWORD*" + " " + BAD_REQUEST_MESSAGE_EMAIL_PASSWORD);
+            throw new BadRequestException(BAD_REQUEST_MESSAGE + "*PASSWORD*" + " " + BAD_REQUEST_MESSAGE_PASSWORD);
         }
+    }
+
+    private void validateUserStatus(Integer status) {
+        if(status != null) {
+            if( status < 0 || status > 1) {
+                throw new BadRequestException(BAD_REQUEST_MESSAGE_STATUS);
+            }
+        }
+
     }
 
     private void validateEmailInTheDataBase(String email) {
@@ -60,4 +70,5 @@ public class UserValidator implements Validator<User> {
             throw new BadRequestException(BAD_REQUEST_MESSAGE + "*EMAIL*" + " " + BAD_REQUEST_MESSAGE_EMAIL_IN_DB);
         }
     }
+
 }

--- a/src/main/java/com/agilethought/atsceapi/validator/ValidationUtils.java
+++ b/src/main/java/com/agilethought/atsceapi/validator/ValidationUtils.java
@@ -19,7 +19,7 @@ public class ValidationUtils {
 
 	static boolean isValidEmail(String email) {
 		Pattern patternEmail = Pattern.compile(
-				"^[_a-z0-9-]+(\\.[_a-z0-9-]+)*@" + "[a-z0-9-]+(\\.[a-z0-9-]+)*(\\.[a-z]{2,4})$"
+				"^[\\p{L}\\p{N}\\._%+-]+@[\\p{L}\\p{N}\\.\\-]+\\.[\\p{L}]{2,}$"
 		);
 		Matcher matcherEmail = patternEmail.matcher(email);
 		return matcherEmail.find();


### PR DESCRIPTION
The user can now gave us the status field with the values null, 0 and 1. If we receive other value, we send a message error of what could happen in that field.
The users' emails now can have the "ñ" letter

## When the user don't type his first name and last name
![imagen](https://user-images.githubusercontent.com/78741607/111691785-47204800-87f4-11eb-9c3c-e0e9fd3f1b0e.png)
![imagen](https://user-images.githubusercontent.com/78741607/111691814-50111980-87f4-11eb-89b5-18b879fdbbb3.png)

## When the user type an invalid email
![imagen](https://user-images.githubusercontent.com/78741607/111691877-661eda00-87f4-11eb-876a-769a096b6628.png)

## When the user type an invalid password
![imagen](https://user-images.githubusercontent.com/78741607/111691945-75058c80-87f4-11eb-9845-5119fcf33a36.png)

## When the user's email it already exist in the database
![imagen](https://user-images.githubusercontent.com/78741607/111692031-95cde200-87f4-11eb-92cc-870e31d3b1a2.png)

