### PR TITLE
Install JaCoCo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,13 @@
             <artifactId>springfox-swagger-ui</artifactId>
             <version>2.9.2</version>
         </dependency>
+        <!-- JaCoCo -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <version>0.8.6</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -115,6 +122,46 @@
                         <configuration>
                             <appName>at-sce-api-qa</appName>
                         </configuration>
+                    </plugin>
+                    <!-- JaCoCo -->
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.6</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>default-check</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <rule>
+                                            <element>BUNDLE</element>
+                                            <limits>
+                                                <limit>
+                                                    <counter>COMPLEXITY</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>0.01</minimum>
+                                                </limit>
+                                            </limits>
+                                        </rule>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,14 @@
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <version>0.8.6</version>
+                        <configuration>
+                            <!-- execute classes -->
+                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
+                            <excludes>
+                                <exclude>com/agilethought/atsceapi/config/**/*</exclude>
+                                <exclude>com/agilethought/atsceapi/model/**/*</exclude>
+                            </excludes>
+                        </configuration>
                         <executions>
                             <execution>
                                 <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,9 @@
                             <excludes>
                                 <exclude>com/agilethought/atsceapi/config/**/*</exclude>
                                 <exclude>com/agilethought/atsceapi/model/**/*</exclude>
+                                <exclude>com/agilethought/atsceapi/domain/**/*</exclude>
+                                <exclude>com/agilethought/atsceapi/exception/**/*</exclude>
+                                <exclude>com/agilethought/atsceapi/dto/**/*</exclude>
                             </excludes>
                         </configuration>
                         <executions>


### PR DESCRIPTION
To see how many code lines are cover with unit testing, JaCoCo will provide us a report if our code lines have their unit testing, also we will use JaCoCo to determine what will be the percentage of unit testing that we need to cover.
To see more details go to https://trello.com/c/wqCwIDRh/77-us-35-nfr-implement-jacoco-on-at-scre-api