### PR TITLE
Move out JaCoCo plugin from profiles tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
@@ -74,7 +73,6 @@
             <artifactId>org.jacoco.agent</artifactId>
             <version>0.8.6</version>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,57 @@
                     </processTypes>
                 </configuration>
             </plugin>
+            <!-- JaCoCo -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
+                <configuration>
+                    <!-- execute classes -->
+                    <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
+                    <excludes>
+                        <exclude>com/agilethought/atsceapi/config/**/*</exclude>
+                        <exclude>com/agilethought/atsceapi/model/**/*</exclude>
+                        <exclude>com/agilethought/atsceapi/domain/**/*</exclude>
+                        <exclude>com/agilethought/atsceapi/exception/**/*</exclude>
+                        <exclude>com/agilethought/atsceapi/dto/**/*</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.01</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -122,57 +173,6 @@
                         <configuration>
                             <appName>at-sce-api-qa</appName>
                         </configuration>
-                    </plugin>
-                    <!-- JaCoCo -->
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.6</version>
-                        <configuration>
-                            <!-- execute classes -->
-                            <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
-                            <excludes>
-                                <exclude>com/agilethought/atsceapi/config/**/*</exclude>
-                                <exclude>com/agilethought/atsceapi/model/**/*</exclude>
-                                <exclude>com/agilethought/atsceapi/domain/**/*</exclude>
-                                <exclude>com/agilethought/atsceapi/exception/**/*</exclude>
-                                <exclude>com/agilethought/atsceapi/dto/**/*</exclude>
-                            </excludes>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>prepare-agent</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>report</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>default-check</id>
-                                <goals>
-                                    <goal>check</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <rule>
-                                            <element>BUNDLE</element>
-                                            <limits>
-                                                <limit>
-                                                    <counter>COMPLEXITY</counter>
-                                                    <value>COVEREDRATIO</value>
-                                                    <minimum>0.01</minimum>
-                                                </limit>
-                                            </limits>
-                                        </rule>
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/src/test/java/com/agilethought/atsceapi/service/UserServiceImplTest.java
+++ b/src/test/java/com/agilethought/atsceapi/service/UserServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.agilethought.atsceapi.service;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
@@ -28,7 +28,7 @@ public class UserServiceImplTest {
     private UserRepository userRepository;
 
     @Mock
-    private MapperFacade userRepositoryMapper;
+    private MapperFacade orikaMapperFacade;
 
     @InjectMocks
     private UserServiceImpl userService;
@@ -39,10 +39,11 @@ public class UserServiceImplTest {
     }
 
     @Test
-    public void itShouldGetAllUsers(){
+    public void getAllUsersTest(){
         when(userRepository.findAll()).thenReturn(new ArrayList<>());
-        when(userRepositoryMapper.mapAsList(anyList(),any())).thenReturn(new ArrayList<>());
+        when(orikaMapperFacade.mapAsList(anyList(),any())).thenReturn(new ArrayList<>());
         List<UserDTO> result = userService.getAllUsers();
         assertNotNull(result);
     }
+
 }

--- a/src/test/java/com/agilethought/atsceapi/service/UserServiceImplTest.java
+++ b/src/test/java/com/agilethought/atsceapi/service/UserServiceImplTest.java
@@ -1,6 +1,6 @@
 package com.agilethought.atsceapi.service;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/agilethought/atsceapi/service/UserServiceImplTest.java
+++ b/src/test/java/com/agilethought/atsceapi/service/UserServiceImplTest.java
@@ -1,12 +1,16 @@
 package com.agilethought.atsceapi.service;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import com.agilethought.atsceapi.service.implementation.UserServiceImpl;
+import ma.glasnost.orika.MapperFacade;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -23,16 +27,21 @@ public class UserServiceImplTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private MapperFacade userRepositoryMapper;
+
     @InjectMocks
     private UserServiceImpl userService;
 
+    @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
     }
 
     @Test
-    public void getAllUsersTest(){
+    public void itShouldGetAllUsers(){
         when(userRepository.findAll()).thenReturn(new ArrayList<>());
+        when(userRepositoryMapper.mapAsList(anyList(),any())).thenReturn(new ArrayList<>());
         List<UserDTO> result = userService.getAllUsers();
         assertNotNull(result);
     }


### PR DESCRIPTION

The JaCoCo plugin was inside from the profiles tag instead of the main
plugins tag, because all the profiles need to use JaCoCo