### PR TITLE
US47 Fix Issues in User PUT operation

### DIFF
--- a/src/main/java/com/agilethought/atsceapi/controller/UserController.java
+++ b/src/main/java/com/agilethought/atsceapi/controller/UserController.java
@@ -106,7 +106,7 @@ public class UserController {
     })
 	public UpdateUserResponse putUser(@RequestBody UpdateUserRequest request, @PathVariable String id) {
 
-        return userService.updateUser(request,id);
+        return userService.updateUserById(request, id);
 
 	}
 	

--- a/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
+++ b/src/main/java/com/agilethought/atsceapi/exception/ErrorMessage.java
@@ -3,6 +3,7 @@ package com.agilethought.atsceapi.exception;
 public class ErrorMessage {
 
     public static final String MISSING_REQUIRED_INPUT = "Required field %s is missing.";
+    public static final String ID = "Id";
 
     public static final String INVALID_INPUT = "Invalid input on field %s. Correct format is: %s";
     public static final String CORRECT_FORMAT_NUMERIC = "A number with or " +

--- a/src/main/java/com/agilethought/atsceapi/service/UserService.java
+++ b/src/main/java/com/agilethought/atsceapi/service/UserService.java
@@ -16,7 +16,7 @@ public interface UserService {
 
 	void deleteUserById(String id);
 	
-	UpdateUserResponse updateUser(
+	UpdateUserResponse updateUserById(
 			UpdateUserRequest request,
 			String id
 	);

--- a/src/main/java/com/agilethought/atsceapi/service/implementation/UserServiceImpl.java
+++ b/src/main/java/com/agilethought/atsceapi/service/implementation/UserServiceImpl.java
@@ -10,12 +10,14 @@ import java.util.Optional;
 
 import com.agilethought.atsceapi.dto.user.*;
 import com.agilethought.atsceapi.service.UserService;
+import com.agilethought.atsceapi.validator.user.LoginValidator;
+import com.agilethought.atsceapi.validator.user.NewUserValidator;
+import com.agilethought.atsceapi.validator.user.UpdateUserValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.agilethought.atsceapi.model.User;
-import com.agilethought.atsceapi.validator.Validator;
-import com.agilethought.atsceapi.validator.user.UserValidator;
+import com.agilethought.atsceapi.validator.user.UserDataValidator;
 import com.agilethought.atsceapi.exception.NotFoundException;
 import com.agilethought.atsceapi.exception.UnauthorizedException;
 import com.agilethought.atsceapi.repository.UserRepository;
@@ -35,10 +37,13 @@ public class UserServiceImpl implements UserService {
 	private MapperFacade orikaMapperFacade;
 
 	@Autowired
-	private Validator<LoginRequest> loginValidator;
+	private LoginValidator loginValidator;
 
 	@Autowired
-	private UserValidator userValidator;
+	private NewUserValidator newUserValidator;
+
+	@Autowired
+	private UpdateUserValidator updateUserValidator;
 
 	@Override
 	public LoginResponse loginUser(LoginRequest loginRequest) {
@@ -97,7 +102,7 @@ public class UserServiceImpl implements UserService {
 	public NewUserResponse createUser(NewUserRequest request) {
 
 		User user = orikaMapperFacade.map(request, User.class);
-		userValidator.validate(user);
+		newUserValidator.validate(user);
 		setLetterCases(user);
 		User savedUsers = userRepository.save(user);
 		return orikaMapperFacade.map(savedUsers, NewUserResponse.class);
@@ -105,16 +110,11 @@ public class UserServiceImpl implements UserService {
 	}
 
 	@Override
-	public UpdateUserResponse updateUser(UpdateUserRequest request, String id) {
+	public UpdateUserResponse updateUserById(UpdateUserRequest request, String id) {
 
-		Optional<User> userFoundById = userRepository.findById(id);
-		if (!userFoundById.isPresent())
-			throw new NotFoundException(
-					String.format(NOT_FOUND_RESOURCE, USER, id)
-			);
 		request.setId(id);
 		User userUpdatedFields = orikaMapperFacade.map(request, User.class);
-		userValidator.validate(userUpdatedFields);
+		updateUserValidator.validate(userUpdatedFields);
 		setLetterCases(userUpdatedFields);
 		User updatedUser = userRepository.save(userUpdatedFields);
 		return orikaMapperFacade.map(updatedUser, UpdateUserResponse.class);

--- a/src/main/java/com/agilethought/atsceapi/service/implementation/UserServiceImpl.java
+++ b/src/main/java/com/agilethought/atsceapi/service/implementation/UserServiceImpl.java
@@ -3,14 +3,12 @@ package com.agilethought.atsceapi.service.implementation;
 import static com.agilethought.atsceapi.exception.ErrorMessage.INVALID_CREDENTIALS;
 import static com.agilethought.atsceapi.exception.ErrorMessage.UNAVAILABLE_ENTITY;
 import static com.agilethought.atsceapi.exception.ErrorMessage.NOT_FOUND_RESOURCE;
-import static com.agilethought.atsceapi.exception.ErrorMessage.ALREADY_EXISTING_EMAIL;
 import static com.agilethought.atsceapi.exception.ErrorMessage.USER;
 
 import java.util.List;
 import java.util.Optional;
 
 import com.agilethought.atsceapi.dto.user.*;
-import com.agilethought.atsceapi.exception.BadRequestException;
 import com.agilethought.atsceapi.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -100,10 +98,6 @@ public class UserServiceImpl implements UserService {
 
 		User user = orikaMapperFacade.map(request, User.class);
 		userValidator.validate(user);
-		if (userRepository.existsByEmail(user.getEmail()))
-			throw new BadRequestException(
-					String.format(ALREADY_EXISTING_EMAIL, user.getEmail())
-			);
 		setLetterCases(user);
 		User savedUsers = userRepository.save(user);
 		return orikaMapperFacade.map(savedUsers, NewUserResponse.class);
@@ -118,18 +112,9 @@ public class UserServiceImpl implements UserService {
 			throw new NotFoundException(
 					String.format(NOT_FOUND_RESOURCE, USER, id)
 			);
-		User userToBeUpdated = userFoundById.get();
 		request.setId(id);
 		User userUpdatedFields = orikaMapperFacade.map(request, User.class);
 		userValidator.validate(userUpdatedFields);
-		if (userRepository.existsByEmail(userUpdatedFields.getEmail()))
-			// If the email in the update request exists, it must be equal
-			// than the one inside the user to be updated. Otherwise, the
-			// email in the request already belongs to somebody else.
-			if (!userUpdatedFields.getEmail().equals(userToBeUpdated.getEmail()))
-				throw new BadRequestException(
-						String.format(ALREADY_EXISTING_EMAIL, userUpdatedFields.getEmail())
-				);
 		setLetterCases(userUpdatedFields);
 		User updatedUser = userRepository.save(userUpdatedFields);
 		return orikaMapperFacade.map(updatedUser, UpdateUserResponse.class);

--- a/src/main/java/com/agilethought/atsceapi/service/implementation/UserServiceImpl.java
+++ b/src/main/java/com/agilethought/atsceapi/service/implementation/UserServiceImpl.java
@@ -118,11 +118,20 @@ public class UserServiceImpl implements UserService {
 			throw new NotFoundException(
 					String.format(NOT_FOUND_RESOURCE, USER, id)
 			);
+		User userToBeUpdated = userFoundById.get();
 		request.setId(id);
-		User user = orikaMapperFacade.map(request, User.class);
-		userValidator.validate(user);
-		setLetterCases(user);
-		User updatedUser = userRepository.save(user);
+		User userUpdatedFields = orikaMapperFacade.map(request, User.class);
+		userValidator.validate(userUpdatedFields);
+		if (userRepository.existsByEmail(userUpdatedFields.getEmail()))
+			// If the email in the update request exists, it must be equal
+			// than the one inside the user to be updated. Otherwise, the
+			// email in the request already belongs to somebody else.
+			if (!userUpdatedFields.getEmail().equals(userToBeUpdated.getEmail()))
+				throw new BadRequestException(
+						String.format(ALREADY_EXISTING_EMAIL, userUpdatedFields.getEmail())
+				);
+		setLetterCases(userUpdatedFields);
+		User updatedUser = userRepository.save(userUpdatedFields);
 		return orikaMapperFacade.map(updatedUser, UpdateUserResponse.class);
 
 	}

--- a/src/main/java/com/agilethought/atsceapi/service/implementation/UserServiceImpl.java
+++ b/src/main/java/com/agilethought/atsceapi/service/implementation/UserServiceImpl.java
@@ -100,10 +100,6 @@ public class UserServiceImpl implements UserService {
 
 		User user = orikaMapperFacade.map(request, User.class);
 		userValidator.validate(user);
-		if (userRepository.existsByEmail(user.getEmail()))
-			throw new BadRequestException(
-					String.format(ALREADY_EXISTING_EMAIL, user.getEmail())
-			);
 		setLetterCases(user);
 		User savedUsers = userRepository.save(user);
 		return orikaMapperFacade.map(savedUsers, NewUserResponse.class);
@@ -118,18 +114,9 @@ public class UserServiceImpl implements UserService {
 			throw new NotFoundException(
 					String.format(NOT_FOUND_RESOURCE, USER, id)
 			);
-		User userToBeUpdated = userFoundById.get();
 		request.setId(id);
 		User userUpdatedFields = orikaMapperFacade.map(request, User.class);
 		userValidator.validate(userUpdatedFields);
-		if (userRepository.existsByEmail(userUpdatedFields.getEmail()))
-			// If the email in the update request exists, it must be equal
-			// than the one inside the user to be updated. Otherwise, the
-			// email in the request already belongs to somebody else.
-			if (!userUpdatedFields.getEmail().equals(userToBeUpdated.getEmail()))
-				throw new BadRequestException(
-						String.format(ALREADY_EXISTING_EMAIL, userUpdatedFields.getEmail())
-				);
 		setLetterCases(userUpdatedFields);
 		User updatedUser = userRepository.save(userUpdatedFields);
 		return orikaMapperFacade.map(updatedUser, UpdateUserResponse.class);

--- a/src/main/java/com/agilethought/atsceapi/validator/user/NewUserValidator.java
+++ b/src/main/java/com/agilethought/atsceapi/validator/user/NewUserValidator.java
@@ -1,0 +1,35 @@
+package com.agilethought.atsceapi.validator.user;
+
+import com.agilethought.atsceapi.exception.BadRequestException;
+import static com.agilethought.atsceapi.exception.ErrorMessage.ALREADY_EXISTING_EMAIL;
+import com.agilethought.atsceapi.model.User;
+import com.agilethought.atsceapi.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NewUserValidator {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserDataValidator userDataValidator;
+
+    public void validate(User user) {
+
+        userDataValidator.validate(user);
+        validateUniqueEmail(user.getEmail());
+
+    }
+
+    private void validateUniqueEmail(String email) {
+
+        if (userRepository.existsByEmail(email))
+            throw new BadRequestException(
+                    String.format(ALREADY_EXISTING_EMAIL, email)
+            );
+
+    }
+
+}

--- a/src/main/java/com/agilethought/atsceapi/validator/user/UpdateUserValidator.java
+++ b/src/main/java/com/agilethought/atsceapi/validator/user/UpdateUserValidator.java
@@ -1,0 +1,62 @@
+package com.agilethought.atsceapi.validator.user;
+
+import com.agilethought.atsceapi.exception.BadRequestException;
+import com.agilethought.atsceapi.exception.NotFoundException;
+import com.agilethought.atsceapi.model.User;
+import com.agilethought.atsceapi.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import static com.agilethought.atsceapi.exception.ErrorMessage.*;
+import static com.agilethought.atsceapi.validator.user.ValidationUtils.*;
+
+@Service
+public class UpdateUserValidator {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserDataValidator userDataValidator;
+
+    public void validate(User user) {
+
+        // If the given id matches a user, we need the email
+        // of that user for the unique email validation.
+        String emailOfUserToUpdate = validateGivenId(user.getId());
+        userDataValidator.validate(user);
+        validateUniqueEmail(user.getEmail(), emailOfUserToUpdate);
+
+    }
+
+    private String validateGivenId(String id) {
+
+        if (!isValidString(id))
+            throw new BadRequestException(
+                    String.format(MISSING_REQUIRED_INPUT, ID)
+            );
+        Optional<User> userFoundById = userRepository.findById(id);
+        if (!userFoundById.isPresent())
+            throw new NotFoundException(
+                    String.format(NOT_FOUND_RESOURCE, USER, id)
+            );
+        return userFoundById.get().getEmail();
+
+    }
+
+    private void validateUniqueEmail(String emailInRequest, String emailOfUserToUpdate) {
+
+        // If the email in the request exists already, we verify it
+        // belongs to the user being updated. Otherwise, it
+        // belongs to somebody else and the request is rejected.
+        if (userRepository.existsByEmail(emailInRequest) && !emailInRequest.equals(emailOfUserToUpdate) ) {
+            throw new BadRequestException(
+                    String.format(ALREADY_EXISTING_EMAIL, emailInRequest)
+            );
+        }
+
+    }
+
+}

--- a/src/main/java/com/agilethought/atsceapi/validator/user/UserDataValidator.java
+++ b/src/main/java/com/agilethought/atsceapi/validator/user/UserDataValidator.java
@@ -3,21 +3,14 @@ package com.agilethought.atsceapi.validator.user;
 import static com.agilethought.atsceapi.exception.ErrorMessage.*;
 import static com.agilethought.atsceapi.validator.user.ValidationUtils.*;
 
-import com.agilethought.atsceapi.repository.UserRepository;
 import com.agilethought.atsceapi.validator.Validator;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.agilethought.atsceapi.exception.BadRequestException;
 import com.agilethought.atsceapi.model.User;
 
-import java.util.Optional;
-
 @Service
-public class UserValidator implements Validator<User> {
-
-    @Autowired
-    private UserRepository userRepository;
+public class UserDataValidator implements Validator<User> {
 
     private static final String TYPE = "Type";
     private static final String CORRECT_FORMAT_TYPE = "Number 1 for admin or number 2 " +
@@ -43,12 +36,6 @@ public class UserValidator implements Validator<User> {
         validateFirstName(user.getFirstName());
         validateLastName(user.getLastName());
         validateEmailFormat(user.getEmail());
-        // If there is no value in the user's id,
-        // it's a new user being created.
-        if (user.getId() == null)
-            validateUniqueEmailForNewUser(user.getEmail());
-        else
-            validateUniqueEmailForExistingUser(user.getEmail(), user.getId());
         validatePassword(user.getPassword());
         validateStatus(user.getStatus());
 
@@ -101,29 +88,6 @@ public class UserValidator implements Validator<User> {
                     String.format(INVALID_INPUT, EMAIL, CORRECT_FORMAT_EMAIL)
             );
         }
-
-    }
-
-    private void validateUniqueEmailForNewUser(String email) {
-
-        if (userRepository.existsByEmail(email))
-            throw new BadRequestException(
-                    String.format(ALREADY_EXISTING_EMAIL, email)
-            );
-
-    }
-
-    private void validateUniqueEmailForExistingUser(String email, String id) {
-
-        Optional<User> userToBeUpdated = userRepository.findById(id);
-        if (userRepository.existsByEmail(email))
-            // If the email in the update request exists, it must be equal
-            // than the one inside the user to be updated. Otherwise, the
-            // email in the request already belongs to somebody else.
-            if (!email.equals(userToBeUpdated.get().getEmail()))
-                throw new BadRequestException(
-                        String.format(ALREADY_EXISTING_EMAIL, email)
-                );
 
     }
 

--- a/src/main/java/com/agilethought/atsceapi/validator/user/UserValidator.java
+++ b/src/main/java/com/agilethought/atsceapi/validator/user/UserValidator.java
@@ -1,19 +1,23 @@
 package com.agilethought.atsceapi.validator.user;
 
+import static com.agilethought.atsceapi.exception.ErrorMessage.*;
 import static com.agilethought.atsceapi.validator.user.ValidationUtils.*;
-import static com.agilethought.atsceapi.exception.ErrorMessage.MISSING_REQUIRED_INPUT;
-import static com.agilethought.atsceapi.exception.ErrorMessage.INVALID_INPUT;
-import static com.agilethought.atsceapi.exception.ErrorMessage.EMAIL;
-import static com.agilethought.atsceapi.exception.ErrorMessage.PASSWORD;
 
+import com.agilethought.atsceapi.repository.UserRepository;
 import com.agilethought.atsceapi.validator.Validator;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.agilethought.atsceapi.exception.BadRequestException;
 import com.agilethought.atsceapi.model.User;
 
+import java.util.Optional;
+
 @Service
 public class UserValidator implements Validator<User> {
+
+    @Autowired
+    private UserRepository userRepository;
 
     private static final String TYPE = "Type";
     private static final String CORRECT_FORMAT_TYPE = "Number 1 for admin or number 2 " +
@@ -38,7 +42,13 @@ public class UserValidator implements Validator<User> {
         validateType(user.getType());
         validateFirstName(user.getFirstName());
         validateLastName(user.getLastName());
-        validateEmail(user.getEmail());
+        validateEmailFormat(user.getEmail());
+        // If there is no value in the user's id,
+        // it's a new user being created.
+        if (user.getId() == null)
+            validateUniqueEmailForNewUser(user.getEmail());
+        else
+            validateUniqueEmailForExistingUser(user.getEmail(), user.getId());
         validatePassword(user.getPassword());
         validateStatus(user.getStatus());
 
@@ -79,7 +89,7 @@ public class UserValidator implements Validator<User> {
 
     }
 
-    private void validateEmail(String email) {
+    private void validateEmailFormat(String email) {
 
         if (!isValidString(email)) {
             throw new BadRequestException(
@@ -91,6 +101,29 @@ public class UserValidator implements Validator<User> {
                     String.format(INVALID_INPUT, EMAIL, CORRECT_FORMAT_EMAIL)
             );
         }
+
+    }
+
+    private void validateUniqueEmailForNewUser(String email) {
+
+        if (userRepository.existsByEmail(email))
+            throw new BadRequestException(
+                    String.format(ALREADY_EXISTING_EMAIL, email)
+            );
+
+    }
+
+    private void validateUniqueEmailForExistingUser(String email, String id) {
+
+        Optional<User> userToBeUpdated = userRepository.findById(id);
+        if (userRepository.existsByEmail(email))
+            // If the email in the update request exists, it must be equal
+            // than the one inside the user to be updated. Otherwise, the
+            // email in the request already belongs to somebody else.
+            if (!email.equals(userToBeUpdated.get().getEmail()))
+                throw new BadRequestException(
+                        String.format(ALREADY_EXISTING_EMAIL, email)
+                );
 
     }
 

--- a/src/test/java/com/agilethought/atsceapi/controller/UserControllerTest.java
+++ b/src/test/java/com/agilethought/atsceapi/controller/UserControllerTest.java
@@ -99,7 +99,7 @@ public class UserControllerTest {
     public void testPutUser() throws Exception {
 
         String putMapping = "/users/1234";
-        when(userService.updateUser(any(UpdateUserRequest.class), anyString()))
+        when(userService.updateUserById(any(UpdateUserRequest.class), anyString()))
                 .thenReturn(new UpdateUserResponse());
         mockMvc.perform(
                 put(REQUEST_MAPPING + putMapping)

--- a/src/test/java/com/agilethought/atsceapi/validator/user/NewUserValidatorTest.java
+++ b/src/test/java/com/agilethought/atsceapi/validator/user/NewUserValidatorTest.java
@@ -1,0 +1,70 @@
+package com.agilethought.atsceapi.validator.user;
+
+import com.agilethought.atsceapi.exception.BadRequestException;
+import com.agilethought.atsceapi.model.User;
+import com.agilethought.atsceapi.repository.UserRepository;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.*;
+import org.mockito.MockitoAnnotations;
+
+public class NewUserValidatorTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserDataValidator userDataValidator;
+
+    @InjectMocks
+    private NewUserValidator newUserValidator;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testCreateUserWithEmailAlreadyTaken() {
+
+        User mockCreateUser = new User();
+        mockCreateUser.setEmail("email_already_taken@example.com");
+
+        doNothing().when(userDataValidator).validate(any());
+        when(userRepository.existsByEmail(anyString())).thenReturn(true);
+        Exception thrownException = assertThrows(
+                BadRequestException.class,
+                () -> {
+                    newUserValidator.validate(mockCreateUser);
+                }
+        );
+        assertEquals(
+                String.format(
+                        "Email %s is already in use, try with another one or login.",
+                        mockCreateUser.getEmail()
+                ),
+                thrownException.getMessage()
+        );
+
+    }
+
+    @Test
+    public void testCreateUserWithNewEmail() {
+
+        User mockCreateUser = new User();
+        mockCreateUser.setEmail("new_unique_email@example.com");
+
+        doNothing().when(userDataValidator).validate(any());
+        when(userRepository.existsByEmail(anyString())).thenReturn(false);
+        assertDoesNotThrow(
+                () -> {
+                    newUserValidator.validate(mockCreateUser);
+                }
+        );
+
+    }
+
+}

--- a/src/test/java/com/agilethought/atsceapi/validator/user/UpdateUserValidatorTest.java
+++ b/src/test/java/com/agilethought/atsceapi/validator/user/UpdateUserValidatorTest.java
@@ -1,0 +1,145 @@
+package com.agilethought.atsceapi.validator.user;
+
+import com.agilethought.atsceapi.exception.BadRequestException;
+import com.agilethought.atsceapi.exception.NotFoundException;
+import com.agilethought.atsceapi.model.User;
+import com.agilethought.atsceapi.repository.UserRepository;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.*;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+public class UpdateUserValidatorTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserDataValidator userDataValidator;
+
+    @InjectMocks
+    private UpdateUserValidator updateUserValidator;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testUpdateUserByIdWithMissingId() {
+
+        User mockUpdateUser = new User();
+
+        Exception thrownException = assertThrows(
+                BadRequestException.class,
+                () -> {
+                    updateUserValidator.validate(mockUpdateUser);
+                }
+        );
+        assertEquals(
+                "Required field Id is missing.",
+                thrownException.getMessage()
+        );
+
+    }
+
+    @Test
+    public void testUpdateUserByIdWithIdNotFound() {
+
+        User mockUpdateUser = new User();
+        mockUpdateUser.setId("mockedId");
+
+        when(userRepository.findById(anyString()))
+                .thenReturn(Optional.empty());
+        Exception thrownException = assertThrows(
+                NotFoundException.class,
+                () -> {
+                    updateUserValidator.validate(mockUpdateUser);
+                }
+        );
+        assertEquals(
+                "User was not found with the given id: mockedId",
+                thrownException.getMessage()
+        );
+
+    }
+
+    @Test
+    public void testUpdateUserByIdWithEmailAlreadyTaken() {
+
+        // A user with email "current_email@example.com" tries
+        // to update its email to "my_email@example.com", but
+        // it's already taken by another user.
+        User mockUpdateRequest = new User();
+        mockUpdateRequest.setId("mockedUserToUpdateId");
+        mockUpdateRequest.setEmail("my_email@example.com");
+
+        User mockOwnerOfEmail = new User();
+        mockOwnerOfEmail.setId("mockedEmailOwnerId");
+        mockOwnerOfEmail.setEmail("my_email@example.com");
+
+        User mockUserToUpdate = new User();
+        mockUserToUpdate.setId("mockedUserToUpdateId");
+        mockUserToUpdate.setEmail("current_email@example.com");
+
+        when(userRepository.findById("mockedUserToUpdateId"))
+                .thenReturn(Optional.of(mockUserToUpdate));
+        doNothing().when(userDataValidator).validate(any());
+        when(userRepository.existsByEmail(anyString())).thenReturn(true);
+        Exception thrownException = assertThrows(
+                BadRequestException.class,
+                () -> {
+                    updateUserValidator.validate(mockUpdateRequest);
+                }
+        );
+        assertEquals(
+                "Email my_email@example.com is already in use, try with another one or login.",
+                thrownException.getMessage()
+        );
+
+    }
+
+    @Test
+    public void testUpdateUserByIdSuccessfullyWithNewEmail() {
+
+        User mockUpdateUser = new User();
+        mockUpdateUser.setId("1234");
+        mockUpdateUser.setEmail("new_unique_email@example.com");
+
+        when(userRepository.findById(anyString()))
+                .thenReturn(Optional.of(mockUpdateUser));
+        doNothing().when(userDataValidator).validate(any());
+        when(userRepository.existsByEmail(anyString())).thenReturn(false);
+        assertDoesNotThrow(
+                () -> {
+                    updateUserValidator.validate(mockUpdateUser);
+                }
+        );
+
+    }
+
+    @Test
+    public void testUpdateUserByIdWithSameEmail() {
+
+        User mockUpdateUser = new User();
+        mockUpdateUser.setId("1234");
+        mockUpdateUser.setEmail("my_same_email@example.com");
+
+        when(userRepository.findById(anyString()))
+                .thenReturn(Optional.of(mockUpdateUser));
+        doNothing().when(userDataValidator).validate(any());
+        when(userRepository.existsByEmail(anyString())).thenReturn(true);
+        assertDoesNotThrow(
+                () -> {
+                    updateUserValidator.validate(mockUpdateUser);
+                }
+        );
+
+    }
+
+}

--- a/src/test/java/com/agilethought/atsceapi/validator/user/UserDataValidatorTest.java
+++ b/src/test/java/com/agilethought/atsceapi/validator/user/UserDataValidatorTest.java
@@ -2,10 +2,18 @@ package com.agilethought.atsceapi.validator.user;
 
 import com.agilethought.atsceapi.exception.BadRequestException;
 import com.agilethought.atsceapi.model.User;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
-public class UserValidatorTest {
+public class UserDataValidatorTest {
+
+    private UserDataValidator userDataValidator;
+
+    @Before
+    public void setup() {
+        userDataValidator = new UserDataValidator();
+    }
 
     @Test
     public void itShouldThrowErrorMessagesInTypeField() {
@@ -21,8 +29,7 @@ public class UserValidatorTest {
                 // Check the message when the type field is null
                 user.setType(null);
                 Exception errorMessageException = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Required field Type is missing.",
@@ -33,8 +40,7 @@ public class UserValidatorTest {
                 // Check the message when the type field is 0
                 user.setType(0);
                 Exception errorMessageException = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Invalid input on field Type. Correct format is: Number 1 for admin or number 2 for normal user",
@@ -45,8 +51,7 @@ public class UserValidatorTest {
                 // Check the message when the type field is -1
                 user.setType(-1);
                 Exception errorMessageException = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Invalid input on field Type. Correct format is: Number 1 for admin or number 2 for normal user",
@@ -57,8 +62,7 @@ public class UserValidatorTest {
                 // Check the message when the type field is 3
                 user.setType(3);
                 Exception errorMessageException = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Invalid input on field Type. Correct format is: Number 1 for admin or number 2 for normal user",
@@ -81,8 +85,7 @@ public class UserValidatorTest {
             () -> {
                 user.setFirstName(null);
                 Exception exception = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Required field First name is missing.",
@@ -92,8 +95,7 @@ public class UserValidatorTest {
             () -> {
                 user.setFirstName("");
                 Exception exception = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Required field First name is missing.",
@@ -103,8 +105,7 @@ public class UserValidatorTest {
             () -> {
                 user.setFirstName("   ");
                 Exception exception = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Required field First name is missing.",
@@ -127,8 +128,7 @@ public class UserValidatorTest {
                 () -> {
                     user.setLastName(null);
                     Exception exception = Assertions.assertThrows(BadRequestException.class, () -> {
-                        UserValidator userValidator = new UserValidator();
-                        userValidator.validate(user);
+                        userDataValidator.validate(user);
                     });
                     Assertions.assertEquals(
                             "Required field Last name is missing.",
@@ -138,8 +138,7 @@ public class UserValidatorTest {
                 () -> {
                     user.setLastName("");
                     Exception exception = Assertions.assertThrows(BadRequestException.class, () -> {
-                        UserValidator userValidator = new UserValidator();
-                        userValidator.validate(user);
+                        userDataValidator.validate(user);
                     });
                     Assertions.assertEquals(
                             "Required field Last name is missing.",
@@ -149,8 +148,7 @@ public class UserValidatorTest {
                 () -> {
                     user.setLastName("   ");
                     Exception exception = Assertions.assertThrows(BadRequestException.class, () -> {
-                        UserValidator userValidator = new UserValidator();
-                        userValidator.validate(user);
+                        userDataValidator.validate(user);
                     });
                     Assertions.assertEquals(
                             "Required field Last name is missing.",
@@ -161,7 +159,7 @@ public class UserValidatorTest {
     }
 
     @Test
-    public void itShouldThrowErrorMessagesInEmailField() {
+    public void itShouldThrowErrorMessagesInEmailFieldFormat() {
         User user = new User();
         user.setType(2);
         user.setFirstName("Owen");
@@ -174,8 +172,7 @@ public class UserValidatorTest {
                 user.setEmail(null);
                 // check if the email is null
                 Exception exception = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Required field Email is missing.",
@@ -185,8 +182,7 @@ public class UserValidatorTest {
             () -> {
                 user.setEmail("");
                 Exception exception = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Required field Email is missing.",
@@ -196,8 +192,7 @@ public class UserValidatorTest {
             () -> {
                 user.setEmail("  ");
                 Exception exception = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals("Required field Email is missing.",
                         exception.getMessage()
@@ -206,8 +201,7 @@ public class UserValidatorTest {
             () -> {
                 user.setEmail("owenexample.com");
                 Exception exception = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Invalid input on field Email. Correct format is: an_accepted-email.example@domain.com.mx",
@@ -217,8 +211,7 @@ public class UserValidatorTest {
             () -> {
                 user.setEmail("owen@example");
                 Exception exception = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Invalid input on field Email. Correct format is: an_accepted-email.example@domain.com.mx",
@@ -241,32 +234,28 @@ public class UserValidatorTest {
             () -> {
                 user.setPassword(null);
                 Exception errorMessagePassword = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals("Required field Password is missing.", errorMessagePassword.getMessage());
             },
             () -> {
                 user.setPassword("");
                 Exception errorMessagePassword = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals("Required field Password is missing.", errorMessagePassword.getMessage());
             },
             () -> {
                 user.setPassword("  ");
                 Exception errorMessagePassword = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals("Required field Password is missing.", errorMessagePassword.getMessage());
             },
             () -> {
                 user.setPassword("hiWorld");
                 Exception errorMessagePassword = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                     "Invalid input on field Password. Correct format is: 10 characters minimum with "
@@ -277,8 +266,7 @@ public class UserValidatorTest {
             () -> {
                 user.setPassword("helloworld");
                 Exception errorMessagePassword = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Invalid input on field Password. Correct format is: 10 characters minimum with "
@@ -289,8 +277,7 @@ public class UserValidatorTest {
             () -> {
                 user.setPassword("helloWorld");
                 Exception errorMessagePassword = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Invalid input on field Password. Correct format is: 10 characters minimum with "
@@ -314,8 +301,7 @@ public class UserValidatorTest {
             () -> {
                 user.setStatus(null);
                 Exception errorMessageStatus = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Required field Status of user is missing.",
@@ -325,8 +311,7 @@ public class UserValidatorTest {
             () -> {
                 user.setStatus(-1);
                 Exception errorMessageStatus = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                     "Invalid input on field Status of user. Correct format is: Number 0 for unavailable or "
@@ -337,8 +322,7 @@ public class UserValidatorTest {
             () -> {
                 user.setStatus(2);
                 Exception errorMessageStatus = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Invalid input on field Status of user. Correct format is: Number 0 for unavailable or "
@@ -349,8 +333,7 @@ public class UserValidatorTest {
             () -> {
                 user.setStatus(10);
                 Exception errorMessageStatus = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Invalid input on field Status of user. Correct format is: Number 0 for unavailable or "
@@ -361,8 +344,7 @@ public class UserValidatorTest {
             () -> {
                 user.setStatus(-10);
                 Exception errorMessageStatus = Assertions.assertThrows(BadRequestException.class, () -> {
-                    UserValidator userValidator = new UserValidator();
-                    userValidator.validate(user);
+                    userDataValidator.validate(user);
                 });
                 Assertions.assertEquals(
                         "Invalid input on field Status of user. Correct format is: Number 0 for unavailable or "
@@ -372,8 +354,7 @@ public class UserValidatorTest {
             },
             () -> {
                 user.setStatus(0);
-                UserValidator userValidator = new UserValidator();
-                userValidator.validate(user);
+                userDataValidator.validate(user);
             }
         );
     }


### PR DESCRIPTION
Fixed an issue in the User PUT operation, now a validation checks if the email inside the request already exists in the Users database. If it does, it must be the same as the user being updated, because otherwise it belongs to another user. If the email inside the request doesn't exist, then that field won't prevent the operation from completing.